### PR TITLE
Fix "Undefined variable $macros" when using filter in a deferred block

### DIFF
--- a/src/DeferredBlockNode.php
+++ b/src/DeferredBlockNode.php
@@ -34,6 +34,7 @@ final class DeferredBlockNode extends BlockNode
             ->addDebugInfo($this)
             ->write("public function block_{$name}_deferred(\$context, array \$blocks = [])\n", "{\n")
             ->indent()
+            ->write("\$macros = \$this->macros;\n")
             ->subcompile($this->getNode('body'))
             ->write("\$this->deferred->resolve(\$this, \$context, \$blocks);\n")
             ->outdent()

--- a/tests/Fixtures/filter.test
+++ b/tests/Fixtures/filter.test
@@ -1,0 +1,10 @@
+--TEST--
+filter
+--TEMPLATE--
+{% block foo deferred %}
+1{% for test in test_array|default([])|filter(test => true) %}{% endfor %}2
+{% endblock %}
+--DATA--
+return []
+--EXPECT--
+12


### PR DESCRIPTION
Fixes https://github.com/rybakit/twig-deferred-extension/issues/13.